### PR TITLE
Fix rejecting handlers of non-derived events

### DIFF
--- a/events.h
+++ b/events.h
@@ -73,6 +73,7 @@ public:
   template<class Derived, class Base>
   void connectHandler(EventListener<Base>* el) {
     static_assert(!std::is_same<Derived, Base>::value, "Can't connect event handler to itself.");
+    static_assert(std::is_base_of<Base, Derived>::value, "The 'Derived' event must be derived from the 'Base' event");
     ListenerHelper<Derived>::listeners->push_back(static_cast<EventListenerPtr>(el));
   }
 

--- a/example.cpp
+++ b/example.cpp
@@ -59,7 +59,8 @@ int main() {
   // A derived event can be handled by a listener for the base event.
   ed.connectHandler<DEvent, AEvent>(bar);
   // ed.connectHandler<AEvent, AEvent>(bar); // An error.
-  // ed.connectHandler<DEvent, BEvent>(bar); // An error -- DEvent is not derived from BEvent.
+  // ed.connectHandler<DEvent, BEvent>(bar); // An error -- bar doesn't handle BEvent
+  // ed.connectHandler<BEvent, AEvent>(bar); // An error -- BEvent is not derived from AEvent.
 
   cout << "Posting AEvent..." << endl;
   ed.post(AEvent());


### PR DESCRIPTION
Also, fix the corresponding example
